### PR TITLE
changed _mqttPort et al. to an unified connection string

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.associations": {
+        "stdexcept": "cpp",
+        "string": "cpp"
+    }
+}

--- a/Serial2Mqtt.cpp
+++ b/Serial2Mqtt.cpp
@@ -81,8 +81,7 @@ void Serial2Mqtt::init() {
 	if(crc == "off") _crc = CRC_OFF;
 
 	_config.setNameSpace("mqtt");
-	_config.get("port", _mqttPort, 1883);
-	_config.get("host", _mqttHost, "test.mosquitto.org");
+	_config.get("connection", _mqttConnection, "tcp://test.mosquitto.org:1883");
 	_config.get("keepAliveInterval", _mqttKeepAliveInterval, 5);
 	_config.get("willMessage", _mqttWillMessage, "false");
 	_mqttWillQos = 0;
@@ -569,9 +568,7 @@ Erc Serial2Mqtt::mqttConnect() {
 	MQTTAsync_connectOptions conn_opts = MQTTAsync_connectOptions_initializer;
 	MQTTAsync_willOptions will_opts = MQTTAsync_willOptions_initializer;
 
-	connection = "tcp://" + _mqttHost + ":";
-	connection += std::to_string(_mqttPort);
-	INFO(" MQTT connecting %s ... for %s ", connection.c_str(), _serialPortShort.c_str());
+	INFO(" MQTT connecting %s ... for %s ", _mqttConnection.c_str(), _serialPortShort.c_str());
 	mqttConnectionState(MS_CONNECTING);
 	MQTTAsync_create(&_client, connection.c_str(), _mqttClientId.c_str(), MQTTCLIENT_PERSISTENCE_NONE, NULL);
 

--- a/Serial2Mqtt.cpp
+++ b/Serial2Mqtt.cpp
@@ -561,7 +561,6 @@ void Serial2Mqtt::mqttConnectionState(MqttConnectionState st) {
 }
 
 Erc Serial2Mqtt::mqttConnect() {
-	string connection;
 	int rc;
 	if(_mqttConnectionState == MS_CONNECTING || _mqttConnectionState == MS_CONNECTED) return E_OK;
 
@@ -570,7 +569,7 @@ Erc Serial2Mqtt::mqttConnect() {
 
 	INFO(" MQTT connecting %s ... for %s ", _mqttConnection.c_str(), _serialPortShort.c_str());
 	mqttConnectionState(MS_CONNECTING);
-	MQTTAsync_create(&_client, connection.c_str(), _mqttClientId.c_str(), MQTTCLIENT_PERSISTENCE_NONE, NULL);
+	MQTTAsync_create(&_client, _mqttConnection.c_str(), _mqttClientId.c_str(), MQTTCLIENT_PERSISTENCE_NONE, NULL);
 
 	MQTTAsync_setCallbacks(_client, this, onConnectionLost, onMessage, onDeliveryComplete); // TODO add ondelivery
 

--- a/Serial2Mqtt.h
+++ b/Serial2Mqtt.h
@@ -43,6 +43,7 @@ class Serial2Mqtt {
 		// MQTT
 		StaticJsonDocument<2048> _jsonDocument;
 
+		string _mqttClientId;
 		string _mqttConnection;
 		uint32_t _mqttKeepAliveInterval;
 		string _mqttWillMessage;

--- a/Serial2Mqtt.h
+++ b/Serial2Mqtt.h
@@ -43,9 +43,7 @@ class Serial2Mqtt {
 		// MQTT
 		StaticJsonDocument<2048> _jsonDocument;
 
-		string _mqttHost;
-		string _mqttClientId;
-		uint16_t _mqttPort;
+		string _mqttConnection;
 		uint32_t _mqttKeepAliveInterval;
 		string _mqttWillMessage;
 		std::string _mqttWillTopic;

--- a/serial2mqtt.json
+++ b/serial2mqtt.json
@@ -1,7 +1,6 @@
 {
     "mqtt": {
-        "host": "pi3.local",
-        "port": 1883
+        "connection": "tcp://test.mosquitto.org:1883"
     },
     "serial": {
         "baudrate": 115200,


### PR DESCRIPTION
Using a connection string is more versatile, because it implements authentication and using of secure connection and websockets in a simple way.