### PR TITLE
serial idle timer fixes

### DIFF
--- a/Serial2Mqtt.cpp
+++ b/Serial2Mqtt.cpp
@@ -119,9 +119,10 @@ void Serial2Mqtt::run() {
 			mqttConnect();
 		}
 	});
-	serialConnectTimer.atInterval(5000).doThis([this]() {
+	serialConnectTimer.atInterval(5000).doThis([this, &serialTimer]() {
 		if(!_serialConnected) {
 			serialConnect();
+			serialTimer.atDelta(5000);
 		}
 	});
 	mqttPublishTimer.atInterval(1000).doThis([this]() {
@@ -130,11 +131,12 @@ void Serial2Mqtt::run() {
 		mqttPublish("src/" + _serial2mqttDevice + "/system/upTime", sUpTime, 0, 0);
 		mqttPublish("src/" + _serial2mqttDevice + "/serial2mqtt/device", _mqttDevice, 0, 0);
 	});
-	serialTimer.atDelta(5000).doThis([this]() {
+	serialTimer.atDelta(5000).doThis([this, &serialTimer]() {
 		if(_serialConnected) {
 			serialDisconnect();
 			WARN(" disconnecting serial no new data received in %d msec", 5000);
 			serialConnect();
+			serialTimer.atDelta(5000);
 		}
 	});
 	if(_mqttConnectionState != MS_CONNECTING) mqttConnect();

--- a/Timer.cpp
+++ b/Timer.cpp
@@ -40,11 +40,11 @@ Timer& Timer::doThis(TimerHandler action){
 void Timer::check(){
 //    INFO(" %lld %lld ",_expiresOn,Sys::millis());
     if ( _expiresOn < Sys::millis() && _active ) {
-        _action();
         if ( _repeat ) {
             _expiresOn=Sys::millis()+_interval;
         } else {
             _active=false;
         }
+        _action();
     }
 }


### PR DESCRIPTION
The serial idle timer only fires at the first time, it won't be rescheduled until the next character will be received. If the serial line is continously silent, it would disconnect & reconnect only once. The fix will rearm the timer after every serial connection.