### PR TITLE
support setting the MQTT clientId, user and password parameters

### DIFF
--- a/Serial2Mqtt.h
+++ b/Serial2Mqtt.h
@@ -52,6 +52,8 @@ class Serial2Mqtt {
 		bool _mqttWillRetained;
 		string _mqttDevice;
 		string _mqttProgrammerTopic;
+		string _mqttUser;
+		string _mqttPassword;
 		uint64_t _startTime;
 
 //	bool _mqttConnected=false;


### PR DESCRIPTION
Support setting the following MQTT parameters from the configuration file:
* clientId
* user
* password