### PR TITLE
Settable timers

### DIFF
--- a/Serial2Mqtt.cpp
+++ b/Serial2Mqtt.cpp
@@ -364,6 +364,8 @@ void Serial2Mqtt::serialRxd() {
 			DEBUG(" read returns %d => errno : %d = %s", erc, errno, strerror(errno));
 			signal(SERIAL_ERROR);
 		} else {
+			DEBUG("EOF received on the serial connection");
+			signal(SERIAL_ERROR);
 			return;
 		}
 	}

--- a/Serial2Mqtt.h
+++ b/Serial2Mqtt.h
@@ -40,6 +40,8 @@ class Serial2Mqtt {
 		CircBuf _serialBuffer;
 		string _binFile;
 		string _programCommand;
+		uint64_t _serialReconnectInterval;
+		uint64_t _serialIdleTimeout;
 		// MQTT
 		StaticJsonDocument<2048> _jsonDocument;
 
@@ -54,6 +56,8 @@ class Serial2Mqtt {
 		string _mqttProgrammerTopic;
 		string _mqttUser;
 		string _mqttPassword;
+		uint64_t _mqttReconnectInterval;
+		uint64_t _mqttPublishInterval;
 		uint64_t _startTime;
 
 //	bool _mqttConnected=false;

--- a/Timer.cpp
+++ b/Timer.cpp
@@ -10,26 +10,35 @@ Timer::~Timer()
 
 Timer& Timer::atInterval(uint32_t msec)
 {
-_repeat=true;
-_active=true;
-_interval=msec;
-_expiresOn=Sys::millis()+_interval;
-return *this;
+    _repeat=true;
+    if (msec > 0) {
+	_active=true;
+	_interval=msec;
+	_expiresOn=Sys::millis()+_interval;
+    } else {
+	_active=false;
+    }
+    return *this;
 }
+
 Timer& Timer::atExpiry(uint64_t msec)
 {
-_repeat=false;
-_active=true;
-_expiresOn=msec;
-return *this;
+    _repeat=false;
+    _active=true;
+    _expiresOn=msec;
+    return *this;
 }
 
 Timer& Timer::atDelta(uint32_t msec)
 {
-_repeat=false;
-_active=true;
-_expiresOn=Sys::millis()+msec;
-return *this;
+    _repeat=false;
+    if (msec > 0) {
+	_active=true;
+	_expiresOn=Sys::millis()+msec;
+    } else {
+	_active=false;
+    }
+    return *this;
 }
 
 Timer& Timer::doThis(TimerHandler action){


### PR DESCRIPTION
The first commit fixes a bug in the serial receiving code. Upon EOF, read(2) returns with 0, which has been an unhandled case.

The second patch makes timers settable from the configuration file.

The third patch lets timers be disabled. Disabling the serial or MQTT reconnection makes the running process useless, so the only logical option is to exit. It could be useful if someone wants e.g. systemd to resolve the error.