### PR TITLE
add JSON protocol messages to notify MCU about MQTT connection/disconnection

### DIFF
--- a/Serial2Mqtt.h
+++ b/Serial2Mqtt.h
@@ -108,6 +108,7 @@ class Serial2Mqtt {
 		              TIMEOUT
 		             } Signal;
 
+		typedef enum { SUBSCRIBE = 0, PUBLISH, CONNECT, DISCONNECT} CMD;
 
 
 
@@ -128,7 +129,7 @@ class Serial2Mqtt {
 		void serialRxd();
 		bool serialGetLine(string& line);
 		void serialHandleLine(string& line);
-		void serialPublish(string topic,Bytes message,int qos,bool retained);
+		void serialPublish(CMD command,string topic,Bytes message,int qos,bool retained);
 		void serialTxd(const string& line);
 		void flashBin(Bytes& msg);
 //	void serialMqttPublish(string topic,Bytes message,int qos,bool retained);


### PR DESCRIPTION
The MCU <-> serial2mqtt protocol lacks messages about MQTT connection/disconnection. The MQTT based alive protocol mostly solves the problem, but if the MQTT broker gets lost and reconnecting rapidly, the disconnected operation would be unnoticed. It could cause problems, because the MCU should reissue the extra subscribe messages and has to issue the retained messages again.