### PR TITLE
add support for remote serial ports accessible by tcp connections

### DIFF
--- a/Serial2Mqtt.h
+++ b/Serial2Mqtt.h
@@ -18,6 +18,7 @@
 #include <asm-generic/ioctls.h>
 #include <sys/ioctl.h>
 #include <Timer.h>
+#include <netdb.h>
 
 using namespace std;
 
@@ -121,6 +122,7 @@ class Serial2Mqtt {
 		Signal waitSignal(uint32_t timeout);
 
 
+		const string& getSerialPortShort(void) const { return _serialPortShort; }
 		void setConfig(Config config);
 		void setSerialPort(string port);
 		void setLogFd(FILE*);

--- a/main.cpp
+++ b/main.cpp
@@ -88,8 +88,7 @@ int main(int argc, char **argv)
             INFO(" starting thread %d",i);
             serial2mqtt[i].run();
         });
-        std::string port= ports[i];
-        SetThreadName(&threads[i],port.substr(8).c_str());
+        SetThreadName(&threads[i],serial2mqtt[i].getSerialPortShort().c_str());
     }
 
 


### PR DESCRIPTION
The following patch adds support for remote serial ports which are accessible by tcp connections. If the serial port name begins with `tcp://`, it will be treated as a tcp address. The following address formats are supported:
* `tcp://127.0.0.1:1111` (using IPv4 addresses)
* `tcp://[::1]:1111` (using IPv6 addresses)
* `tcp://localhost:1111` (using domain names)

Using the domain name format, the code tries every address record returned by the resolver.