### PR TITLE
silent interval to eliminate corrupted messages upon serial connection

### DIFF
--- a/Serial2Mqtt.cpp
+++ b/Serial2Mqtt.cpp
@@ -180,6 +180,7 @@ void Serial2Mqtt::init()
 		_crc = CRC_OFF;
 	_config.get("reconnectInterval", _serialReconnectInterval, 5000);
 	_config.get("idleTimeout", _serialIdleTimeout, 5000);
+	_config.get("silentInterval", _serialSilentInterval, 0);
 
 	_config.setNameSpace("mqtt");
 	_config.get("connection", _mqttConnection, "tcp://test.mosquitto.org:1883");
@@ -353,7 +354,8 @@ void Serial2Mqtt::run()
 			case MQTT_CONNECT_SUCCESS:
 			{
 				INFO("MQTT_CONNECT_SUCCESS %s ", _serialPortShort.c_str());
-				serialPublish(CONNECT, _mqttDevice, nullmsg, 0, false);
+				if (_serialConnected)
+					serialPublish(CONNECT, _mqttDevice, nullmsg, 0, false);
 				mqttConnectionState(MS_CONNECTED);
 				mqttSubscribe(_mqttSubscribedTo);
 				break;
@@ -602,6 +604,13 @@ Erc Serial2Mqtt::serialConnect()
 		    if ( ioctl( _serialFd, TIOCMSET, &status )<0)
 			ERROR("ioctl()<0 '%s' errno : %d : %s ",_serialPort.c_str(), errno, strerror(errno));
 		*/
+
+		if (_serialSilentInterval > 0)
+		{
+			INFO("silent interval started for %lu msec", _serialSilentInterval);
+			Sys::delay(_serialSilentInterval);
+			tcflush(_serialFd, TCIOFLUSH);
+		}
 	}
 	_serialConnected = true;
 
@@ -1143,14 +1152,12 @@ void Serial2Mqtt::onConnectFailure(void *context, MQTTAsync_failureData *respons
 {
 	Serial2Mqtt *me = (Serial2Mqtt *)context;
 	me->signal(MQTT_CONNECT_FAIL);
-	me->mqttConnectionState(MS_DISCONNECTED);
 }
 
 void Serial2Mqtt::onConnectSuccess(void *context, MQTTAsync_successData *response)
 {
 	Serial2Mqtt *me = (Serial2Mqtt *)context;
 	me->signal(MQTT_CONNECT_SUCCESS);
-	me->mqttConnectionState(MS_CONNECTED);
 }
 
 void Serial2Mqtt::onSubscribeSuccess(void *context, MQTTAsync_successData *response)

--- a/Serial2Mqtt.h
+++ b/Serial2Mqtt.h
@@ -43,6 +43,7 @@ class Serial2Mqtt
 	string _programCommand;
 	uint64_t _serialReconnectInterval;
 	uint64_t _serialIdleTimeout;
+	uint32_t _serialSilentInterval;
 	// MQTT
 	StaticJsonDocument<2048> _jsonDocument;
 

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -11,6 +11,7 @@ The serial group describes how to access the serial port, and how to communicate
 * `protocol` specifies how to communicate with the MCU, valid values are `jsonObject` (default) and `jsonArray`.
 * `reconnectInterval` is the time interval between loosing the serial connection and the reconnection starts. It is specified in milliseconds, the default value is `5000`. You can disable serial reconnection with `0` value, in this case serial2mqtt will exit upon serial disconnection.
 * `idleTimeout` is the maximal time interval without communication. Upon exceeding this limit, the serial connection will be closed and reopened. It is specified in milliseconds, the default value is `5000`. You can disable this functionality with `0` (can be useful during development and testing, but not recommented in production environment).
+* `silentInterval` specifies the interval right after opening the serial device when all traffic will be discared. Its purpose is to let the bootloader run or avoid corrupted data appearing using USB ports. It is specified in milliseconds, the default value is `0` which disables this functionality.
 
 ### Serial port device format
 Serial ports can be local (traditional serial ports, USB dongles, bluetooth etc. accessible by a character device) or remote. Remote serial ports are serial ports on a remote machine, terminal server etc. shared over the network, e.g. this setup [when the MCU is directly connected to an OpenWRT router](https://github.com/vortex314/serial2mqtt/issues/8).


### PR DESCRIPTION
Right after opening, an USB serial port can contain buffered data (see https://github.com/vortex314/serial2mqtt/issues/16 for details):
https://stackoverflow.com/questions/13013387/clearing-the-serial-ports-buffer

This new functionality helps eliminating the problem. Setting to 1000 has solved my problem.