### PR TITLE
Serial fix

### DIFF
--- a/Serial2Mqtt.cpp
+++ b/Serial2Mqtt.cpp
@@ -583,6 +583,7 @@ Erc Serial2Mqtt::serialConnect()
 		options.c_cc[VTIME] = 0;
 		options.c_cc[VMIN] = 1;
 		options.c_iflag |= IGNCR; // ignore carriage return
+		options.c_oflag &= ~(ONLCR | OCRNL | ONOCR | ONLRET); // our output is CR-LF terminated properly
 		//    cfmakeraw(&options);
 		if (cfsetispeed(&options, baudSymbol(_serialBaudrate)) < 0)
 		{


### PR DESCRIPTION
This PR fixes two minor serial handling bugs:
* your code properly terminated every line with a CR-LF sequence, but the terminal layer replaced the LF character with a CR-LF sequence (so the real output was CR-CR-LF). It's not nice and just wastes the serial bandwidth.
* the second commit is a fix for a possible data corruption/loss. Upon an MQTT message burst, the serial output buffer gets full and we will get back EAGAIN or EWOULDBLOCK errors (easy to reproduce with a mosquitto_pub in a loop). This patch handles a corner case too, when only partial writes are possible.