### PR TITLE
fix the serial connection setup documentation and add logging parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ participant MQTT Broker
 activate serial2mqtt
 serial2mqtt-->>µC: open serial port tty
 serial2mqtt-->>MQTT Broker: connect(broker,port)
+serial2mqtt-->>µC: [1,"SOMETHING","SOMETHING",0,1]   replaying saved local persistence messages even before the MQTT connection establishment
 MQTT Broker -->> serial2mqtt: connAck
-serial2mqtt-->>µC: [2,"DEVICE",0]
+serial2mqtt-->>µC: [2,"DEVICE",""]
 µC->> serial2mqtt: [0,"dst/DEVICE/+"]
 µC->> serial2mqtt : [1,"dst/DEVICE/system/loopback","true"]
 deactivate serial2mqtt
@@ -117,7 +118,7 @@ MQTT Broker-->>serial2mqtt: disconnects
 serial2mqtt-->>µC: [3,"",""]
 serial2mqtt-->>MQTT Broker: connect(broker,port)
 MQTT Broker -->> serial2mqtt: connAck
-serial2mqtt-->>µC: [2,"DEVICE",0]
+serial2mqtt-->>µC: [2,"DEVICE",""]
 ```
 # Programming through serial2mqtt
 A command line utility will send a single mqtt request to the serial2mqtt gateway to program the microcontroller.

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -1,7 +1,8 @@
 # Configuring serial2mqtt
 Most of the serial2mqtt options can be set from its configuration file. The configuration is in JSON format, and unless specified, located in the current directory named `serial2mqtt.json`. The whole file is a JSON object, built from the following groups:
 * `serial` for serial port related parameters,
-* `mqtt` for MQTT related parameters, and
+* `mqtt` for MQTT related parameters,
+* `log` for logging parameters, and
 * `programmer`
 
 ## The `serial` group
@@ -60,3 +61,11 @@ Here's an example:
         "localPersistenceDir": "/var/serial2mqtt",
         "localPersistenceFilters": ["hvac/controller/+/set"]
 ```
+
+## The `log` group
+The log group configures how to handle logging:
+* `protocol` controls whether the serial protocol logging is enabled or disabled, default value is `false`.
+* `debug` controls whether debug logging is enabled or disabled, default value is `true`.
+* `mqtt` controls whether MQTT related logging is enabled or disabled, default value is `false`.
+* `program` controls whether the MCU firmware programming logging is enabled or disabled, default value is `false`.
+* `useColors` controls whether the logging messages are colored or not. Default value is `true`.


### PR DESCRIPTION
There were errors in the MQTT-CONN(2) message examples, fixed.

Documentation about the new logging options has been added.