### PR TITLE
configuration reading fixed

### DIFF
--- a/Serial2Mqtt.cpp
+++ b/Serial2Mqtt.cpp
@@ -151,9 +151,9 @@ void Serial2Mqtt::init()
 	_protocol = JSON_OBJECT;
 	if (protocol == "jsonObject")
 		_protocol = JSON_OBJECT;
-	if (protocol == "jsonArray")
+	else if (protocol == "jsonArray")
 		_protocol = JSON_ARRAY;
-	if (protocol == "protobuf")
+	else if (protocol == "protobuf")
 		_protocol = PROTOBUF;
 
 	JsonObject conf = _config.root();
@@ -165,18 +165,18 @@ void Serial2Mqtt::init()
 
 	if (_logUseColors == false)
 	{
+		_colorTxd = "";
+		_colorRxd = "";
 		_colorDebug = "";
 		_colorDefault = "";
-		_colorDebug = "";
-		_colorTxd = "";
 	}
 
 	std::string crc;
-	_config.get("protocol", crc, "off");
+	_config.get("crc", crc, "off");
 	_crc = CRC_OFF;
 	if (crc == "on")
 		_crc = CRC_ON;
-	if (crc == "off")
+	else if (crc == "off")
 		_crc = CRC_OFF;
 	_config.get("reconnectInterval", _serialReconnectInterval, 5000);
 	_config.get("idleTimeout", _serialIdleTimeout, 5000);


### PR DESCRIPTION
Fixed two errors during the configuration reading:
* a copy & paste error when colorized logging is disabled.
* the `crc` parameter couldn't be set.

Not an error, but maybe it's nicer to use if / else if / else if construction similar to switch / case / case, than independent if constructions.