### PR TITLE
QoS and retained flag of the will message can be set from the config

### DIFF
--- a/Serial2Mqtt.cpp
+++ b/Serial2Mqtt.cpp
@@ -189,8 +189,8 @@ void Serial2Mqtt::init()
 	_config.get("connection", _mqttConnection, "tcp://test.mosquitto.org:1883");
 	_config.get("keepAliveInterval", _mqttKeepAliveInterval, 5);
 	_config.get("willMessage", _mqttWillMessage, "false");
-	_mqttWillQos = 0;
-	_mqttWillRetained = false;
+	_config.get("willQos", _mqttWillQos, 0);
+	_config.get("willRetained", _mqttWillRetained, false);
 	_serial2mqttDevice = Sys::hostname();
 	_serial2mqttDevice += "." + _serialPortShort;
 	_mqttDevice = _serial2mqttDevice;

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -32,6 +32,8 @@ The mqtt group configures how to connect to the MQTT broker, and the extra funct
 * `keepAliveInterval` is the MQTT keepalive interval parameter in seconds, default value is `5`.
 * `willTopic` is the MQTT topic where the LWT message will be sent. Default value is `src/<hostname>.<serialPortShort>/serial2mqtt/alive`.
 * `willMessage` is the message body of the LWT message sent to `willTopic`. Default value is `false`.
+* `willQos` is the QoS of the LWT message. Default value is `0`.
+* `willRetained` is the retained flag of the LWT message. Default value is `false`.
 * `clientId` is the MQTT client identifier, must be unique on the broker. Default value is `<hostname>.<serialPortShort><process-id>`.
 * `user` is the user for MQTT authentication. Default value is an empty string, which means no authentication.
 * `password` is the password for MQTT authentication. Default value is an empty string.


### PR DESCRIPTION
It's useful to set the retained flag and the QoS of the Last Will and Testament message. Setting `willRetained` to `true` and `willQos` to `1` creates a persistent alive=false message even if the serial2mqtt process isn't running.