### PR TITLE
Minor fixes

### DIFF
--- a/Serial2Mqtt.cpp
+++ b/Serial2Mqtt.cpp
@@ -177,8 +177,8 @@ void Serial2Mqtt::init()
 
 	if (_logUseColors == false)
 	{
-		_colorTxd = "";
-		_colorRxd = "";
+		_colorTxd = "S-TX: ";
+		_colorRxd = "S-RX: ";
 		_colorDebug = "";
 		_colorDefault = "";
 	}

--- a/Serial2Mqtt.cpp
+++ b/Serial2Mqtt.cpp
@@ -514,7 +514,7 @@ void Serial2Mqtt::reportStatus(const std::string &topic)
 	_jsonDocument.clear();
 	JsonObject msg = _jsonDocument.to<JsonObject>();
 
-	msg["Uptime"] = std::to_string((Sys::millis() - _startTime) / 1000);
+	msg["Uptime"] = (Sys::millis() - _startTime) / 1000;
 	msg["SerialIsConnected"] = _serialConnected;
 	msg["SerialConnectionCount"] = _serialConnectionCount;
 	msg["SerialConnectionErrors"] = _serialConnectionErrors;
@@ -526,7 +526,7 @@ void Serial2Mqtt::reportStatus(const std::string &topic)
 
 	std::string s;
 	serializeJson(msg, s);
-	mqttPublish("src/" + _serial2mqttDevice + "/serial2mqtt/status", s, 0, 0);
+	mqttPublish(topic, s, 0, 0);
 }
 
 Erc Serial2Mqtt::serialConnect()

--- a/Serial2Mqtt.cpp
+++ b/Serial2Mqtt.cpp
@@ -688,7 +688,7 @@ void Serial2Mqtt::serialRxd()
 	size_t space;
 	char buffer[1024];
 	int erc;
-	while (_serialBuffer.size() < 1024) // just a magic limit to avoid memory overflow for nonsense
+	while ((space = _serialBuffer.space()) > 0)
 	{
 		erc = read(_serialFd, buffer, min(space, sizeof(buffer)));
 		if (erc > 0)


### PR DESCRIPTION
Three minor fixes today :-)
* the new metric reporting contained two minor copy & paste errors. The uptime was reported as a string instead of an integer, and the function got the target topic as an argument but never used the parameter,
* the received and sent data is easy to read if log colorization is enabled, but it's undistinguishable in the opposite case. A short prefix should solve this problem in this case,
* the third one is a fix for a fix of a fix :-) I fixed the read buffer size calculation some months ago, but it's revealed a problem in the CircBuf implementation. You reverted half of the modification, so currently the code contains an unitialized variable (`space`) later used in `min()`. In the meantime you fixed the CircBuf code, so it's better to reapply the whole size calculation.