### PR TITLE
closing the serial device twice upon errors, accidentally closed the stdin

### DIFF
--- a/Serial2Mqtt.cpp
+++ b/Serial2Mqtt.cpp
@@ -671,10 +671,13 @@ Erc Serial2Mqtt::serialConnect()
 
 void Serial2Mqtt::serialDisconnect()
 {
-	INFO("serial close(%d)", _serialFd);
-	close(_serialFd);
-	_serialFd = 0;
-	_serialConnected = false;
+	if (_serialConnected)
+	{
+		INFO("serial close(%d)", _serialFd);
+		close(_serialFd);
+		_serialFd = 0;
+		_serialConnected = false;
+	}
 
 	if (_serialReconnectInterval < 1)
 	{


### PR DESCRIPTION
Sometimes upon serial errors, the serial2mqtt tried to close the serial device twice. There was no guard whether the serial device was open or not, just tried to close the fd in `_serialFd`. After a close we set it to 0, so in this case we closed fd 0 (stdin).