### PR TITLE
the sleep(UINT32_MAX) has exited on OpenWRT instantly

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -92,7 +92,10 @@ int main(int argc, char **argv)
         SetThreadName(&threads[i], serial2mqtt[i].getSerialPortShort().c_str());
     }
 
-    sleep(UINT32_MAX); // UINT32_MAX to sleep 'forever'
+    for (;;)
+    {
+	sleep(INT32_MAX);
+    }
     exit(0);
 
     return 0;


### PR DESCRIPTION
The sleep(UINT32_MAX) has exited instantly on OpenWrt. This fix will work forever :-)