### PR TITLE
add link to the OpenWrt package

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ Everything that serial2mqtt receives on the serial port is also send on a topic.
     unzip serial2mqtt.`arch`.zip
     mv Debug/serial2mqtt.`arch` serial2mqtt
     
+There's an [experimental OpenWrt package](https://github.com/halfbakery/serial2mqtt-openwrt),
+you can build az ipk package from the git head tailored to your system in
+less than 5 minutes.
+
+
 # Configuration
 See [Configuring serial2mqtt](doc/CONFIGURATION.md) for details.
     


### PR DESCRIPTION
Add a link how to build an OpenWrt package. Serial2mqtt has been running fine on old tp-link router for 5 hours :-)