### PR TITLE
it's better to use %llu instead of %d for uint64_t

### DIFF
--- a/Serial2Mqtt.cpp
+++ b/Serial2Mqtt.cpp
@@ -326,7 +326,7 @@ void Serial2Mqtt::run()
 	serialTimer.atDelta(_serialIdleTimeout).doThis([this, &serialTimer]() {
 		if (_serialConnected)
 		{
-			WARN("disconnecting serial no new data received in %d msec", _serialIdleTimeout);
+			WARN("disconnecting serial no new data received in %llu msec", _serialIdleTimeout);
 			serialDisconnect();
 			serialConnect();
 			serialTimer.atDelta(_serialIdleTimeout);


### PR DESCRIPTION
A log (printf) format string used `%d` for `uint64_t` value, which displayed incorrectly on 32 bit systems.