### PR TITLE
Update the build intrsuctions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ if(PAHO_BUILD_STATIC)
     set(_PAHO_MQTT_C_LIB_NAME ${_PAHO_MQTT_C_LIB_NAME}-static)
 endif()
 find_package(eclipse-paho-mqtt-c REQUIRED)
+find_package(OpenSSL REQUIRED)
 add_definitions(-DLINUX -std=c++11)
 add_executable(serial2mqtt)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,12 +3,7 @@ project(serial2mqtt VERSION 0.1.0)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g ")
 set(CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS} -g ")
-set(PAHO_MQTT_C_LIBRARIES paho.mqtt.c) 
-# add suffix when using static Paho MQTT C library variant
-if(PAHO_BUILD_STATIC)
-    set(_PAHO_MQTT_C_LIB_NAME ${_PAHO_MQTT_C_LIB_NAME}-static)
-endif()
-find_package(eclipse-paho-mqtt-c REQUIRED)
+
 find_package(OpenSSL REQUIRED)
 add_definitions(-DLINUX -std=c++11)
 add_executable(serial2mqtt)
@@ -26,17 +21,22 @@ target_sources(serial2mqtt PRIVATE
     src/CircBuf.cpp 
     src/Sema.cpp 
     ) 
-    
+
+# added paho.mqtt.c/src for paho-mqtt-c header files
 include_directories(src  
     ArduinoJson/src 
+    paho.mqtt.c/src
     )
 
+#Where to find the lib "libpaho-mqtt3as.a", libssl and libcrypto
+link_directories(${CMAKE_SOURCE_DIR}/paho.mqtt.c/src /usr/local/lib)
+
+# added libpaho-mqtt3as.a, libssl.a and libcrypto.a as we build in static mode
 target_link_libraries(serial2mqtt 
-    eclipse-paho-mqtt-c::paho-mqtt3as-static
+    libpaho-mqtt3as.a
+    -l:libssl.a
+    -l:libcrypto.a
     -lpthread 
     -lrt 
     -pthread 
     -latomic )
-    
- 
-    

--- a/README.md
+++ b/README.md
@@ -142,12 +142,29 @@ deactivate serial2mqtt
 ```
 # Logging through serial2mqtt
 Everything that serial2mqtt receives on the serial port is also send on a topic. The micrcontroller will also log to the central logging system 
+
 # Build instructions
-- `serial2mqtt` is leveraging `paho-mqtt-c` library in secure mode, therefore it requires OpenSSL. Install libssl-dev: `apt-get  install libssl-dev`
-- clone repository and submodules: `git clone --recurse-submodules https://github.com/vortex314/serial2mqtt.git`
-- `cd serial2mqtt`
-- `cd paho.mqtt.c && cmake -DPAHO_BUILD_STATIC=true -DPAHO_WITH_SSL=true && make && cd ..`
-- back in serial2mqtt folder: `mkdir build && cd build && cmake .. && make`
+Tested with Ubuntu 22.04.4 LTS Desktop 64 bits and Ubuntu 22.04.4 LTS Server 64 bits.
+
+These instructions should fit any Linux distribution, suh as Debian (including Raspberry Pi) and Ubuntu distribution.
+
+`serial2mqtt` is leveraging `paho-mqtt-c` library in secure mode, therefore it requires OpenSSL and crypto library.
+
+Here are the build commands:
+```
+sudo apt-get  install libssl-dev
+git clone --recurse-submodules https://github.com/vortex314/serial2mqtt.git
+cd serial2mqtt
+cd paho.mqtt.c
+cmake -DPAHO_BUILD_STATIC=true -DPAHO_WITH_SSL=true
+cmake --build .
+make
+cd ..
+mkdir build
+cd build
+cmake ..
+make
+```
     
 There's an [experimental OpenWrt package](https://github.com/halfbakery/serial2mqtt-openwrt),
 you can build az ipk package from the git head tailored to your system in

--- a/README.md
+++ b/README.md
@@ -141,14 +141,13 @@ MQTT Broker ->> programmer CLI : logs
 deactivate serial2mqtt
 ```
 # Logging through serial2mqtt
-Everything that serial2mqtt receives on the serial port is also send on a topic.The micrcontroller will also log to the central logging system 
+Everything that serial2mqtt receives on the serial port is also send on a topic. The micrcontroller will also log to the central logging system 
 # Build instructions
-- install libssl-dev ( apt-get  install libssl-dev )
-- git clone --recurse-submodules https://github.com/vortex314/serial2mqtt.git
-- cd serial2mqtt
-- cd paho.mqtt.c &&  cmake -DPAHO_BUILD_STATIC=true && make && cd ..
-- in serial2mqtt folder : mkdir build && cd build && cmake .. && make
-
+- `serial2mqtt` is leveraging `paho-mqtt-c` library in secure mode, therefore it requires OpenSSL. Install libssl-dev: `apt-get  install libssl-dev`
+- clone repository and submodules: `git clone --recurse-submodules https://github.com/vortex314/serial2mqtt.git`
+- `cd serial2mqtt`
+- `cd paho.mqtt.c && cmake -DPAHO_BUILD_STATIC=true -DPAHO_WITH_SSL=true && make && cd ..`
+- back in serial2mqtt folder: `mkdir build && cd build && cmake .. && make`
     
 There's an [experimental OpenWrt package](https://github.com/halfbakery/serial2mqtt-openwrt),
 you can build az ipk package from the git head tailored to your system in


### PR DESCRIPTION
When I tested the build instructions on my Ubuntu server computer, it failed to build.

I realized that the paho-mqtt-c build process was unusual, and I found how to make it work on my computer.

So I propose here some build instructions compatible with Ubuntu, and most probably it should be compatible with any Linux distribution. CMakeLists.txt has been simplified and include and library dirs have been explicitely mentionned.

However, as I don't know at all ESP32 NodeMcu, I have no idea whether those new instructions are compatible. And even how to build/compile. I made it clear in the README that the build instructions were tested on two Ubuntu computers.

If something was done the wrong way, I apologize in advance and ask you to share with me your comments, so that I fix what I can.